### PR TITLE
Fix links to kortforsyning status

### DIFF
--- a/about-html/about.html
+++ b/about-html/about.html
@@ -162,6 +162,6 @@
   	Notice, if your qlr-file includes local data, only people with access to these data, are able to add the layers from the Kortforsyningsmenu.</p>
   <H2 id="servicestatus">Status of the service</H2>	
   <p>
-  	The plugin uses services from the Kortforsyning. Check out the <a href='https://www.site24x7.com/sv.do?id=I0s1DBEcJmIQQ4zzx%2FsZd8HMN7GkuJ926JxdfdUY3JWh%2FR1xZMoA295dRuHP2wNqvWBeo9R4VTt2%0AlZX81BIklHoiIFDuVU4z"'>status of the services.</a></p>
+  	The plugin uses services from the Kortforsyning. Check out the <a href="https://www.site24x7.com/sv.do?id=I0s1DBEcJmIQQ4zzx%2FsZd8HMN7GkuJ926JxdfdUY3JWh%2FR1xZMoA295dRuHP2wNqvWBeo9R4VTt2%0AlZX81BIklHoiIFDuVU4z">status of the services.</a></p>
   </body>
 </html>

--- a/about-html/qgis3about.html
+++ b/about-html/qgis3about.html
@@ -162,6 +162,6 @@
   	Notice, if your qlr-file includes local data, only people with access to these data, are able to add the layers from the Kortforsyningsmenu.</p>
   <H2 id="servicestatus">Status of the service</H2>	
   <p>
-  	The plugin uses services from the Kortforsyning. Check out the <a href='https://www.site24x7.com/sv.do?id=I0s1DBEcJmIQQ4zzx%2FsZd8HMN7GkuJ926JxdfdUY3JWh%2FR1xZMoA295dRuHP2wNqvWBeo9R4VTt2%0AlZX81BIklHoiIFDuVU4z"'>status of the services.</a></p>
+  	The plugin uses services from the Kortforsyning. Check out the <a href="https://www.site24x7.com/sv.do?id=I0s1DBEcJmIQQ4zzx%2FsZd8HMN7GkuJ926JxdfdUY3JWh%2FR1xZMoA295dRuHP2wNqvWBeo9R4VTt2%0AlZX81BIklHoiIFDuVU4z">status of the services.</a></p>
   </body>
 </html>


### PR DESCRIPTION
The links to the uptime monitoring in the about pages are malformed (including an extra ") but easy to fix.